### PR TITLE
Aktualizacja django_start_project/README

### DIFF
--- a/pl/django_start_project/README.md
+++ b/pl/django_start_project/README.md
@@ -71,6 +71,15 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'public', 'static')
 ```
 
+## Ustawienie ALLOWED_HOSTS
+
+Lista ALLOWED_HOSTS jest pusta, domyślne ustawienie hosta to:  [ 'localhost', '127.0.0.1', '[:: 1]']. Jednak wdrożenie to nie będzie działać w PythonAnywhere, więc zmień ustawienie na poniższe:
+
+```python
+ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
+```
+Dzięki temu unikniemy błędu Invalid HTTP_HOST header (you may need to set ALLOWED_HOSTS)
+
 ## Ustawienie bazy danych
 
 Istnieje duży wybór baz danych, w których możemy trzymać dane naszej strony. My użyjemy bazy domyślnej, czyli `sqlite3`.


### PR DESCRIPTION
Lista ALLOWED_HOSTS była pusta, a domyślne ustawienie jej hosta to:  [ 'localhost', '127.0.0.1', '[:: 1]']. Jednak wdrożenie to nie działa w PythonAnywhere. Dodałam ustawienie ALLOWED_HOST na współpracujące z PythonAnywhere.  Pomaga uniknąć błędu: Invalid HTTP_HOST header (you may need to set ALLOWED_HOSTS). Wzorzec: https://github.com/DjangoGirls/tutorial/pull/934/commits/4f0af44942105b124a1c3d288f420919350b2559